### PR TITLE
Lazyload iframes and images

### DIFF
--- a/resources/js/components/EmbedFieldtype.vue
+++ b/resources/js/components/EmbedFieldtype.vue
@@ -31,7 +31,7 @@
                 :class="{ 'p-2 pb-0': info.code.borderRadius }"
             >
                 <div
-                    v-html="info.code.html"
+                    v-html="info.code.htmlLazy || info.code.html"
                     class="relative overflow-hidden [&_iframe]:w-full! [&_iframe]:max-w-none! [&_iframe]:h-full! [&_iframe]:border-0"
                     :class="{
                         'aspect-(--embed-ratio)': info.code.ratio,

--- a/resources/js/components/EmbedFieldtype.vue
+++ b/resources/js/components/EmbedFieldtype.vue
@@ -48,6 +48,7 @@
             <img
                 v-else-if="shouldShowImage && info.image"
                 :src="info.image.url"
+                loading="lazy"
                 :class="{
                     'w-full h-auto': !shouldEnforceImage,
                     'flex-0 h-24 w-auto max-w-1/3! self-stretch object-cover': shouldEnforceImage

--- a/resources/js/components/EmbedFieldtype.vue
+++ b/resources/js/components/EmbedFieldtype.vue
@@ -47,8 +47,10 @@
 
             <img
                 v-else-if="shouldShowImage && info.image"
-                :src="info.image.url"
                 loading="lazy"
+                :src="info.image.url"
+                :width="info.image.width"
+                :height="info.image.height"
                 :class="{
                     'w-full h-auto': !shouldEnforceImage,
                     'flex-0 h-24 w-auto max-w-1/3! self-stretch object-cover': shouldEnforceImage

--- a/src/Http/Resources/EmbedResource.php
+++ b/src/Http/Resources/EmbedResource.php
@@ -88,9 +88,12 @@ class EmbedResource extends JsonResource
         $ratio = $width && $height ? $width / $height : 0;
         $orientation = $ratio ? ($ratio >= 1 ? 'landscape' : 'portrait') : null;
 
+        $htmlLazy = str_ireplace('<iframe', '<iframe loading="lazy"', $html);
+
         return [
             'type' => $type,
             'html' => $html,
+            'htmlLazy' => $htmlLazy,
             'width' => $width,
             'maxWidth' => $maxWidth,
             'height' => $height,


### PR DESCRIPTION
- Only load iframes and images when they become visible in the control panel
- Improves performance of edit forms with many embeds, such as in repeaters or grids