### PR TITLE
Cast resolved URIs to strings so embed data is cache- and JSON-safe

### DIFF
--- a/src/Http/Resources/EmbedResource.php
+++ b/src/Http/Resources/EmbedResource.php
@@ -23,7 +23,7 @@ class EmbedResource extends JsonResource
     public function toArray($request): array
     {
         return [
-            'url' => $this->resource->url ?? null,
+            'url' => $this->stringify($this->resource->url),
             'title' => $this->resource->title ?? null,
             'description' => $this->resource->description ?? null,
             'language' => $this->resource->language ?? null,
@@ -43,7 +43,7 @@ class EmbedResource extends JsonResource
         return ($name || $url) ? [
             'name' => $name,
             'slug' => $slug,
-            'url' => $this->resource->providerUrl ?? null,
+            'url' => $this->stringify($url),
         ] : null;
     }
 
@@ -54,8 +54,16 @@ class EmbedResource extends JsonResource
 
         return $name ? [
             'name' => $name,
-            'url' => $url,
+            'url' => $this->stringify($url),
         ] : null;
+    }
+
+    /**
+     * Cast a value (such as a PSR-7 URI object) to a string, preserving null.
+     */
+    protected function stringify(mixed $value): ?string
+    {
+        return $value !== null ? (string) $value : null;
     }
 
     protected function code(): ?array

--- a/tests/Unit/EmbedResourceTest.php
+++ b/tests/Unit/EmbedResourceTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use Daun\StatamicEmbed\Http\Resources\EmbedResource;
+use GuzzleHttp\Psr7\Uri;
+use Illuminate\Http\Request;
+
+it('casts uri objects to strings so the payload is json- and cache-safe', function () {
+    // The Embed library exposes url/providerUrl/authorUrl as PSR-7 UriInterface
+    // objects. This stand-in mirrors that shape.
+    $resource = new class
+    {
+        public Uri $url;
+
+        public ?string $title = 'Test video';
+
+        public ?string $description = null;
+
+        public ?string $language = null;
+
+        public $code = null;
+
+        public $image = null;
+
+        public ?string $providerName = 'YouTube';
+
+        public Uri $providerUrl;
+
+        public ?string $authorName = 'Some Author';
+
+        public Uri $authorUrl;
+
+        public function __construct()
+        {
+            $this->url = new Uri('https://www.youtube.com/watch?v=abc');
+            $this->providerUrl = new Uri('https://www.youtube.com');
+            $this->authorUrl = new Uri('https://www.youtube.com/@author');
+        }
+
+        public function getOEmbed()
+        {
+            return new class
+            {
+                public function all(): array
+                {
+                    return [];
+                }
+            };
+        }
+    };
+
+    $data = (new EmbedResource($resource))->resolve(new Request);
+
+    expect($data['url'])->toBe('https://www.youtube.com/watch?v=abc');
+    expect($data['provider']['url'])->toBe('https://www.youtube.com');
+    expect($data['author']['url'])->toBe('https://www.youtube.com/@author');
+});


### PR DESCRIPTION
### Problem

`EmbedResource` returns `url`, `provider.url` and `author.url` as PSR-7 `UriInterface` objects (`GuzzleHttp\Psr7\Uri`). Since `EmbedService` caches the resolved array, those objects get serialized. Apps that harden cache deserialization with `config/cache.php` → `'serializable_classes' => false` (the default in new Laravel apps) can't unserialize them, so cached reads come back as `__PHP_Incomplete_Class` — breaking the control-panel preview and front-end augmentation on any cache hit. The objects also aren't representable via `json_encode`.

**Before:**
<img width="1732" height="226" alt="CleanShot 2026-07-14 at 19 08 42@2x" src="https://github.com/user-attachments/assets/7d15e7c9-7e6a-4942-9557-bfb2796863b1" />



**After:**
<img width="1740" height="262" alt="CleanShot 2026-07-14 at 19 06 53@2x" src="https://github.com/user-attachments/assets/aaa19c9b-1e83-4b1c-b4ed-e768839cf063" />



### Change

Cast the three URIs to strings with a small `stringify()` helper (preserving `null`), matching how `image` is already handled. The resolved payload is now entirely primitives.

### Tests

Adds `tests/Unit/EmbedResourceTest.php` asserting `url`, `provider.url` and `author.url` resolve to strings. It fails without the change and passes with it.
